### PR TITLE
setup.cfg: install_requires = file: requirements.txt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,17 +15,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-install_requires =
-    aiohttp==3.8.1
-    aiosignal==1.2.0
-    async-timeout==4.0.2
-    attrs==21.4.0
-    charset-normalizer==2.1.0
-    frozenlist==1.3.0
-    idna==3.3
-    multidict==6.0.2
-    setuptools==63.1.0 
-    yarl==1.7.2
+install_requires = file: requirements.txt
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Simplify `setup.cfg` and allow `requirements.txt` to be the single source of truth about dependencies.

Testing:
* `pipx install --force git+https://github.com/cclauss/FConnch.git@patch-1`